### PR TITLE
Remove format, level from logger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ config :demo, :wlan0, ssid: "yourssid",  key_mgmt: :"WPA-PSK",  psk: "yourwifipa
 #### config.exs
 ```elixir
 config :logger,
-        backends: [ :console, LoggerMulticastBackend ],
-        level: :debug,
-        format: "$time $metadata[$level] $message\n"
+        backends: [ :console, LoggerMulticastBackend ]
 ```
 
 #### watching log during an update

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,9 +9,7 @@ config :demo, :wlan0, ssid: "boo",  key_mgmt: :"WPA-PSK",  psk: "thunderstruck"
 
 # config.exs
 config :logger,
-        backends: [ :console, LoggerMulticastBackend ],
-        level: :debug,
-        format: "$time $metadata[$level] $message\n"
+        backends: [ :console, LoggerMulticastBackend ]
 
 config :nerves_cell, Mix.Project.config
 


### PR DESCRIPTION
Changing the logger format at this level doesn't do the expected thing, so remove it.
The level defaults to debug, so I removed that as well to minimize typing. I didn't test
these changes in this project, but they now match what I'm doing in a different live-coded
presentation.